### PR TITLE
Add GitHub Action to automatically mark stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Mark stale issues and PRs
-        uses: actions/stale@28c0b7fbe1c4c9cbead9f7d5c3e2de3c8c0e5f6c
+        uses: actions/stale@9d5a0b4d7a0d8b4f2c5e7d5b8a6c2a3f7a2b1c9d
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,4 +32,3 @@ jobs:
 
           stale-issue-label: stale
           stale-pr-label: stale
-          

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Mark Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: "0 1 * * *"  # runs daily
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mark stale issues and PRs
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-stale: 30
+          days-before-close: 7
+
+          stale-issue-message: >
+            This issue has been automatically marked as stale due to inactivity.
+            It will be closed if no further activity occurs.
+
+          stale-pr-message: >
+            This pull request has been automatically marked as stale due to inactivity.
+
+          stale-issue-label: stale
+          stale-pr-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,12 @@ name: Mark Stale Issues and PRs
 
 on:
   schedule:
-    - cron: "0 1 * * *"  # runs daily
+    - cron: "0 1 * * *"
   workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:
@@ -11,7 +15,7 @@ jobs:
 
     steps:
       - name: Mark stale issues and PRs
-        uses: actions/stale@v9
+        uses: actions/stale@28c0b7fbe1c4c9cbead9f7d5c3e2de3c8c0e5f6c
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -20,10 +24,12 @@ jobs:
 
           stale-issue-message: >
             This issue has been automatically marked as stale due to inactivity.
-            It will be closed if no further activity occurs.
+            It will be closed if no further activity occurs within 7 days.
 
           stale-pr-message: >
             This pull request has been automatically marked as stale due to inactivity.
+            It will be closed if no further activity occurs within 7 days.
 
           stale-issue-label: stale
           stale-pr-label: stale
+          


### PR DESCRIPTION
## Description

This PR introduces a GitHub Action workflow to automatically mark inactive
issues and pull requests as stale.

If there is no activity for a period of time:
- Issues and PRs are marked as stale after 30 days
- They are automatically closed after 7 additional days of inactivity

## Implementation

Added workflow:

.github/workflows/stale.yml

The workflow runs daily using a scheduled GitHub Action and uses
`actions/stale` to detect inactive issues and pull requests.

## Benefits

- Keeps the repository clean
- Reduces manual maintenance
- Helps maintainers focus on active issues

###  Screenshots/Recordings:
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->


###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated management of stale issues and pull requests is now enabled. Inactive items will be marked as stale after 30 days of inactivity and closed after 7 additional days with no updates. The process runs daily and can be triggered manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->