### PR TITLE
docs: fix TODO placeholders in CONTRIBUTING.md with SmartNotes-specific content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to TODO: Project Name
+# Contributing to SmartNotes
 
 ⭐ First off, thank you for considering contributing to this project! ⭐
 
@@ -56,7 +56,10 @@ Feature suggestions are welcome! Please:
 
 ### Prerequisites
 
-TODO: List prerequisites specific to your project
+- [Node.js](https://nodejs.org/) v18 or higher
+- [npm](https://www.npmjs.com/) v9 or higher (comes with Node.js)
+- [Git](https://git-scm.com/)
+- A code editor (VS Code recommended)
 
 ### Setup
 
@@ -67,13 +70,13 @@ TODO: List prerequisites specific to your project
 
 2. **Clone Your Fork**
    ```bash
-   git clone https://github.com/YOUR_USERNAME/TODO.git
-   cd TODO
+   git clone https://github.com/YOUR_USERNAME/SmartNotes.git
+   cd SmartNotes
    ```
 
 3. **Add Upstream Remote**
    ```bash
-   git remote add upstream https://github.com/AOSSIE-Org/TODO.git
+   git remote add upstream https://github.com/AOSSIE-Org/SmartNotes.git
    ```
 
 4. **Install Dependencies**
@@ -109,12 +112,15 @@ git checkout -b fix/your-bug-fix
 
 ### 3. Test Your Changes
 
-TODO: Add project-specific testing instructions
-
 ```bash
-npm test
-# or
+# Run linter
 npm run lint
+
+# Check formatting
+npm run format
+
+# Run the app in development mode to test your changes
+npm run dev
 ```
 
 ### 4. Commit Your Changes
@@ -204,7 +210,7 @@ Steps to test the changes
 
 ## 📝 Code Style Guidelines
 
-TODO: Add project-specific code style guidelines
+SmartNotes uses [Biome](https://biomejs.dev/) for linting and formatting. Run `npm run lint` before committing.
 
 ### General Guidelines
 
@@ -255,4 +261,4 @@ TODO: Add project-specific code style guidelines
 - Check for existing PRs before starting to avoid duplication
 
 
-Thank you for contributing to TODO! Your efforts help make this project better for everyone. 🚀
+Thank you for contributing to SmartNotes! Your efforts help make this project better for everyone. 🚀


### PR DESCRIPTION
## Summary

The `CONTRIBUTING.md` file contained several unfilled template placeholders left over from project setup. These are confusing for new contributors who follow the guide.

**Changes:**
- Line 1: `# Contributing to TODO: Project Name` ? `# Contributing to SmartNotes`
- Line 59: Generic `TODO: List prerequisites` ? actual prerequisites (Node.js v18+, npm v9+, Git)
- Lines 70-76: `TODO.git` clone URLs ? correct `SmartNotes.git` URLs
- Line 112: `TODO: Add project-specific testing instructions` ? actual `npm run dev` / `npm run lint` commands
- Line 207: `TODO: Add project-specific code style guidelines` ? reference to Biome linter
- Line 258: `Thank you for contributing to TODO!` ? `SmartNotes`

## Test plan
- [x] Read through CONTRIBUTING.md to confirm all TODO placeholders are replaced
- [x] Verified clone URLs point to the correct `AOSSIE-Org/SmartNotes` repository
- [x] Prerequisites match the project's actual tech stack (Node.js + npm)

?? Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated contribution guidelines with SmartNotes-specific details
* Added explicit prerequisite requirements (Node.js v18+, npm v9+, Git, code editor)
* Clarified development setup instructions with repository clone and upstream configuration steps
* Updated testing and development commands with concrete command references
* Established code style standards using automated linting and formatting tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->